### PR TITLE
add competition vision track links

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ The competitions are open to all field robotics researchers and practitioners.
 Please visit the competition websites for more details:
 
 **Vision Tracks:**
- - [GOOSE + GOOSE-Ex: 2D Semantic Segmentation Challenge](#) (start date: February 7, 2025)
- - [GOOSE + GOOSE-Ex: 3D Semantic Segmentation Challenge](#) (start date: February 7, 2025)
+ - [GOOSE 2D Semantic Segmentation Challenge](https://tinyurl.com/goose-2d-challenge)
+ - [GOOSE 3D Semantic Segmentation Challenge](https://tinyurl.com/goose-3d-challenge)
 
 **SLAM Tracks:**
  - coming soon...


### PR DESCRIPTION
I've completed the setup of the 2D and 3D semantic segmentation competitions for the GOOSE and GOOSE-Ex datasets.
Here are the links to the competition pages on Codabench.